### PR TITLE
feat: Add logging to main & renderer

### DIFF
--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -3,7 +3,10 @@ const fs = require('fs');
 const Database = require('better-sqlite3');
 const { app } = require('electron');
 
+const log = require('./utils/logger.cjs');
+
 const dbDir = path.join(app.getPath('userData'), 'db');
+log.info("Database Directory: ", dbDir);
 if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir);
 
 const dbPath = path.join(dbDir, 'app.db');

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,6 +1,8 @@
 const { app, BrowserWindow, ipcMain, Tray, Menu } = require('electron');
 const path = require('path');
 
+const log = require('./utils/logger.cjs');
+
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
@@ -15,8 +17,8 @@ const isDev = !app.isPackaged;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 400,
-    height: 300,
+    width: 500,
+    height: 500,
     webPreferences: {
       preload: path.join(__dirname, 'preload.cjs'),
       contextIsolation: true,
@@ -28,7 +30,7 @@ function createWindow() {
     mainWindow.loadURL('http://localhost:5173');
   } else {
     const indexPath = path.join(app.getAppPath(), 'dist', 'index.html');
-    console.log('Trying to load:', indexPath);
+    log.debug('Trying to load:', indexPath);
     mainWindow.loadFile(indexPath);
   }
 
@@ -50,11 +52,13 @@ app.whenReady().then(() => {
     { label: 'Quit', click: () => app.quit() }
   ]));
 
+  log.info('Electron app booting...');
+
   setInterval(() => {
     const current = db.prepare('SELECT value FROM counters WHERE id = 1').get()?.value || 0;
     const newValue = current + 1;
     db.prepare('INSERT OR REPLACE INTO counters (id, value) VALUES (1, ?)').run(newValue);
-    console.log('Counter electron/main.cjs:', newValue);
+    log.info('Counter:', newValue);
   }, 4000);
 });
 
@@ -75,8 +79,28 @@ ipcMain.handle('get-counter', async () => {
 });
 
 ipcMain.handle('increment-counter', () => {
+  log.debug('Increament query executed successfully');
   const current = db.prepare('SELECT value FROM counters WHERE id = 1').get()?.value || 0;
   const newValue = current + 1;
   db.prepare('INSERT OR REPLACE INTO counters (id, value) VALUES (1, ?)').run(newValue);
   return newValue;
+});
+
+ipcMain.on('log', (event, level, message) => {
+  switch (level) {
+    case 'info':
+      log.raw.info(message);
+      break;
+    case 'warn':
+      log.raw.warn(message);
+      break;
+    case 'error':
+      log.raw.error(message);
+      break;
+    case 'debug':
+      log.raw.debug(message);
+      break;
+    default:
+      log.raw.info(message);
+  }
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -4,3 +4,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getCounter: () => ipcRenderer.invoke('get-counter'),
   incrementCounter: () => ipcRenderer.invoke('increment-counter')
 });
+
+contextBridge.exposeInMainWorld('logger', {
+  info: (msg) => ipcRenderer.send('log', 'info', msg),
+  warn: (msg) => ipcRenderer.send('log', 'warn', msg),
+  error: (msg) => ipcRenderer.send('log', 'error', msg),
+  debug: (msg) => ipcRenderer.send('log', 'debug', msg)
+});

--- a/electron/utils/logger.cjs
+++ b/electron/utils/logger.cjs
@@ -1,0 +1,64 @@
+const log = require('electron-log');
+const path = require('path');
+const fs = require('fs');
+
+const logPath = log.transports.file.getFile?.().path ?? 'log-fallback.log';
+// console.log('Log file path:', logPath);
+
+if (!fs.existsSync(path.dirname(logPath))) {
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+}
+
+log.transports.file.resolvePathFn = () => logPath;
+log.transports.file.maxSize = 5 * 1024 * 1024; // 5MB max size before rotation
+log.transports.file.format = '{y}-{m}-{d} {h}:{i}:{s} [{level}] {text}';
+
+// Add file + line info to log
+function getCallerInfo() {
+  const originalStack = new Error().stack?.split('\n') ?? [];
+  
+  // Skip the first 2-3 lines (error message + logger function call)
+  const callerStackLine = originalStack.find(line =>
+    line.includes('at') && !line.includes('logger.cjs') // filter out internal logger calls
+  );
+
+  if (!callerStackLine) return 'unknown';
+
+  // Match the file path, line and column (with or without wrapping parentheses)
+  const match = callerStackLine.match(/(?:at\s+.*?\()?([A-Z]:\\.*?):(\d+):(\d+)\)?/i);
+  if (!match) return 'unknown';
+
+  const filePath = match[1];
+  const line = match[2];
+  return `${filePath}:${line}`;
+}
+
+// Pretty-format objects & support multiple args
+function formatArgs(args) {
+  return args.map(arg =>
+    typeof arg === 'object' ? JSON.stringify(arg, null, 2) : arg
+  ).join(' ');
+}
+
+function logWithOrigin(level, ...args) {
+  const origin = getCallerInfo();
+  log[level](`[${origin}] ${formatArgs(args)}`);
+}
+
+// main process -- logs with file name and line number
+// renderer process - logs without filename or line number
+module.exports = {
+  // Use these in Electron code
+  info: (...args) => logWithOrigin('info', ...args),
+  warn: (...args) => logWithOrigin('warn', ...args),
+  error: (...args) => logWithOrigin('error', ...args),
+  debug: (...args) => logWithOrigin('debug', ...args),
+
+  // Use these in main to log renderer events
+  raw: {
+    info: (...args) => log.info('[Renderer]', ...args),
+    warn: (...args) => log.warn('[Renderer]', ...args),
+    error: (...args) => log.error('[Renderer]', ...args),
+    debug: (...args) => log.debug('[Renderer]', ...args),
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
+        "electron-log": "^5.4.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -3973,6 +3974,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.1.tgz",
+      "integrity": "sha512-QvisA18Z++8E3Th0zmhUelys9dEv7aIeXJlbFw3UrxCc8H9qSRW0j8/ooTef/EtHui8tVmbKSL+EIQzP9GoRLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.2.0",
+    "electron-log": "^5.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ function App() {
   }, []);
 
   const handleClick = async () => {
+    window.logger.info('Button Clicked');
     const updated = await window.electronAPI.incrementCounter();
     setCount(updated);
   };


### PR DESCRIPTION
Added logging setup for the main process and the renderer process. 

main process -- logs with file name and line number
renderer process - logs without filename or line number

In development environment, both the logs from main and renderer are visible in the terminal.
log file path: C:\Users\<user profile>\AppData\Roaming\hiredue\logs

**Excludes:**
logs from the renderer process do not include the file from which the log originated. No feasible solution was found for this yet.