### PR TITLE
refactor(electron): Add ipc and service layer

### DIFF
--- a/electron/db/db.cjs
+++ b/electron/db/db.cjs
@@ -3,7 +3,7 @@ const fs = require('fs');
 const Database = require('better-sqlite3');
 const { app } = require('electron');
 
-const log = require('./utils/logger.cjs');
+const log = require('../utils/logger.cjs');
 
 const dbDir = path.join(app.getPath('userData'), 'db');
 log.info("Database Directory: ", dbDir);
@@ -14,16 +14,16 @@ const db = new Database(dbPath);
 
 // Example: init
 db.exec(`
-  CREATE TABLE IF NOT EXISTS counters (
-    id INTEGER PRIMARY KEY,
-    value INTEGER
-  );
+    CREATE TABLE IF NOT EXISTS counters (
+        id INTEGER PRIMARY KEY,
+        value INTEGER
+    );
 `);
 
 // Insert a row with id=1 and value=0 if it doesn't already exist
 const row = db.prepare('SELECT 1 FROM counters WHERE id = 1').get();
 if (!row) {
-  db.prepare('INSERT INTO counters (id, value) VALUES (1, 0)').run();
+    db.prepare('INSERT INTO counters (id, value) VALUES (1, 0)').run();
 }
 
 module.exports = db;

--- a/electron/ipc/counter.ipc.cjs
+++ b/electron/ipc/counter.ipc.cjs
@@ -1,0 +1,15 @@
+const { ipcMain } = require('electron');
+
+const {getCounter, incrementCounter} = require('../services/counter.service.cjs');
+const log = require('../utils/logger.cjs');
+
+module.exports = function registerCounterIPC() {
+    ipcMain.handle('get-counter', () => {
+        return getCounter();
+    });
+
+    ipcMain.handle('increment-counter', () => {
+        log.debug('Trigger: Increment Counter IPC Layer');
+        return incrementCounter();
+    });
+};

--- a/electron/ipc/logger.ipc.cjs
+++ b/electron/ipc/logger.ipc.cjs
@@ -1,0 +1,12 @@
+const { ipcMain } = require('electron');
+const log = require('../utils/logger.cjs');
+
+module.exports = function registerLoggerIPC() {
+    ipcMain.on('log', (event, level, message) => {
+        if (typeof log.raw[level] === 'function') {
+            log.raw[level](message);
+        } else {
+            log.raw.info(message);
+        }
+    });
+};

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,106 +1,70 @@
-const { app, BrowserWindow, ipcMain, Tray, Menu } = require('electron');
+const { app, BrowserWindow, Tray, Menu } = require('electron');
 const path = require('path');
 
 const log = require('./utils/logger.cjs');
-
-const gotTheLock = app.requestSingleInstanceLock();
-if (!gotTheLock) {
-  app.quit();
-  return;
-}
-
-const db = require('./db.cjs');
+const { createIncreamentCounterJob } = require('./services/counter.service.cjs');
+const registerCounterIPC = require('./ipc/counter.ipc.cjs');
+const registerLoggerIPC = require('./ipc/logger.ipc.cjs');
 
 let tray = null;
 let mainWindow = null;
 const isDev = !app.isPackaged;
 
+const gotTheLock = app.requestSingleInstanceLock();
+if (!gotTheLock) {
+    app.quit();
+    return;
+}
+
 function createWindow() {
-  mainWindow = new BrowserWindow({
-    width: 500,
-    height: 500,
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.cjs'),
-      contextIsolation: true,
-      nodeIntegration: false
+    mainWindow = new BrowserWindow({
+        width: 500,
+        height: 500,
+        webPreferences: {
+            preload: path.join(__dirname, 'preload.cjs'),
+            contextIsolation: true,
+            nodeIntegration: false
+        }
+    });
+
+    if (isDev) {
+        mainWindow.loadURL('http://localhost:5173');
+    } else {
+        const indexPath = path.join(app.getAppPath(), 'dist', 'index.html');
+        log.info('Loading production file:', indexPath);
+        mainWindow.loadFile(indexPath);
     }
-  });
 
-  if (isDev) {
-    mainWindow.loadURL('http://localhost:5173');
-  } else {
-    const indexPath = path.join(app.getAppPath(), 'dist', 'index.html');
-    log.debug('Trying to load:', indexPath);
-    mainWindow.loadFile(indexPath);
-  }
-
-  // mainWindow.loadURL('http://localhost:5173');
-
-  mainWindow.on('close', (e) => {
-    e.preventDefault();
-    mainWindow.hide();
-  });
+    mainWindow.on('close', (e) => {
+        e.preventDefault();
+        mainWindow.hide();
+    });
 }
 
 app.whenReady().then(() => {
-  createWindow();
+    createWindow();
 
-  tray = new Tray(path.join(__dirname, 'icon.png')); // Replace with a real icon
-  tray.setToolTip('HireDue');
-  tray.setContextMenu(Menu.buildFromTemplate([
-    { label: 'Show GUI', click: () => mainWindow.show() },
-    { label: 'Quit', click: () => app.quit() }
-  ]));
+    tray = new Tray(path.join(__dirname, 'icon.png'));
+    tray.setToolTip('HireDue');
+    tray.setContextMenu(Menu.buildFromTemplate([
+        { label: 'Show GUI', click: () => mainWindow.show() },
+        { label: 'Quit', click: () => app.quit() }
+    ]));
 
-  log.info('Electron app booting...');
+    log.info('Electron app booting...');
 
-  setInterval(() => {
-    const current = db.prepare('SELECT value FROM counters WHERE id = 1').get()?.value || 0;
-    const newValue = current + 1;
-    db.prepare('INSERT OR REPLACE INTO counters (id, value) VALUES (1, ?)').run(newValue);
-    log.info('Counter:', newValue);
-  }, 4000);
+    registerCounterIPC();
+    registerLoggerIPC();
+
+    createIncreamentCounterJob(); // Background counter update
 });
 
 app.on('second-instance', () => {
-  if (mainWindow) {
-    if (mainWindow.isMinimized()) mainWindow.restore();
-    mainWindow.show();
-    mainWindow.focus();
-  } else {
-    createWindow(); // recreate window if it was destroyed
-  }
-});
-
-
-ipcMain.handle('get-counter', async () => {
-  const row = db.prepare('SELECT value FROM counters WHERE id = 1').get();
-  return row?.value;
-});
-
-ipcMain.handle('increment-counter', () => {
-  log.debug('Increament query executed successfully');
-  const current = db.prepare('SELECT value FROM counters WHERE id = 1').get()?.value || 0;
-  const newValue = current + 1;
-  db.prepare('INSERT OR REPLACE INTO counters (id, value) VALUES (1, ?)').run(newValue);
-  return newValue;
-});
-
-ipcMain.on('log', (event, level, message) => {
-  switch (level) {
-    case 'info':
-      log.raw.info(message);
-      break;
-    case 'warn':
-      log.raw.warn(message);
-      break;
-    case 'error':
-      log.raw.error(message);
-      break;
-    case 'debug':
-      log.raw.debug(message);
-      break;
-    default:
-      log.raw.info(message);
-  }
+    if (mainWindow) {
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.show();
+        mainWindow.focus();
+    } else {
+        createWindow();
+    }
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,13 +1,13 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  getCounter: () => ipcRenderer.invoke('get-counter'),
-  incrementCounter: () => ipcRenderer.invoke('increment-counter')
+    getCounter: () => ipcRenderer.invoke('get-counter'),
+    incrementCounter: () => ipcRenderer.invoke('increment-counter')
 });
 
 contextBridge.exposeInMainWorld('logger', {
-  info: (msg) => ipcRenderer.send('log', 'info', msg),
-  warn: (msg) => ipcRenderer.send('log', 'warn', msg),
-  error: (msg) => ipcRenderer.send('log', 'error', msg),
-  debug: (msg) => ipcRenderer.send('log', 'debug', msg)
+    info: (msg) => ipcRenderer.send('log', 'info', msg),
+    warn: (msg) => ipcRenderer.send('log', 'warn', msg),
+    error: (msg) => ipcRenderer.send('log', 'error', msg),
+    debug: (msg) => ipcRenderer.send('log', 'debug', msg)
 });

--- a/electron/services/counter.service.cjs
+++ b/electron/services/counter.service.cjs
@@ -1,0 +1,31 @@
+const db = require('../db/db.cjs');
+const log = require('../utils/logger.cjs');
+
+
+function getCounter() {
+    // log.debug("Get Counter Service Layer");
+    const row = db.prepare('SELECT value FROM counters WHERE id = 1').get();
+    return row?.value || 0;
+}
+
+function incrementCounter() {
+    log.debug("Increament Counter Service Layer");
+    const current = getCounter();
+    const newValue = current + 1;
+    db.prepare('INSERT OR REPLACE INTO counters (id, value) VALUES (1, ?)').run(newValue);
+    return newValue;
+}
+
+function createIncreamentCounterJob() {
+    log.debug("Job: Increament Counter Service Layer");
+    setInterval(() => {
+        const newValue = incrementCounter();
+        log.info('Background counter incremented:', newValue);
+    }, 4000);
+}
+
+module.exports = {
+    createIncreamentCounterJob,
+    getCounter,
+    incrementCounter
+};

--- a/electron/utils/logger.cjs
+++ b/electron/utils/logger.cjs
@@ -3,10 +3,9 @@ const path = require('path');
 const fs = require('fs');
 
 const logPath = log.transports.file.getFile?.().path ?? 'log-fallback.log';
-// console.log('Log file path:', logPath);
 
 if (!fs.existsSync(path.dirname(logPath))) {
-  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
 }
 
 log.transports.file.resolvePathFn = () => logPath;
@@ -15,50 +14,50 @@ log.transports.file.format = '{y}-{m}-{d} {h}:{i}:{s} [{level}] {text}';
 
 // Add file + line info to log
 function getCallerInfo() {
-  const originalStack = new Error().stack?.split('\n') ?? [];
+    const originalStack = new Error().stack?.split('\n') ?? [];
   
-  // Skip the first 2-3 lines (error message + logger function call)
-  const callerStackLine = originalStack.find(line =>
-    line.includes('at') && !line.includes('logger.cjs') // filter out internal logger calls
-  );
+    // Skip the first 2-3 lines (error message + logger function call)
+    const callerStackLine = originalStack.find(line =>
+        line.includes('at') && !line.includes('logger.cjs') // filter out internal logger calls
+    );
 
-  if (!callerStackLine) return 'unknown';
+    if (!callerStackLine) return 'unknown';
 
-  // Match the file path, line and column (with or without wrapping parentheses)
-  const match = callerStackLine.match(/(?:at\s+.*?\()?([A-Z]:\\.*?):(\d+):(\d+)\)?/i);
-  if (!match) return 'unknown';
+    // Match the file path, line and column (with or without wrapping parentheses)
+    const match = callerStackLine.match(/(?:at\s+.*?\()?([A-Z]:\\.*?):(\d+):(\d+)\)?/i);
+    if (!match) return 'unknown';
 
-  const filePath = match[1];
-  const line = match[2];
-  return `${filePath}:${line}`;
+    const filePath = match[1];
+    const line = match[2];
+    return `${filePath}:${line}`;
 }
 
 // Pretty-format objects & support multiple args
 function formatArgs(args) {
-  return args.map(arg =>
-    typeof arg === 'object' ? JSON.stringify(arg, null, 2) : arg
-  ).join(' ');
+    return args.map(arg =>
+        typeof arg === 'object' ? JSON.stringify(arg, null, 2) : arg
+    ).join(' ');
 }
 
 function logWithOrigin(level, ...args) {
-  const origin = getCallerInfo();
-  log[level](`[${origin}] ${formatArgs(args)}`);
+    const origin = getCallerInfo();
+    log[level](`[${origin}] ${formatArgs(args)}`);
 }
 
 // main process -- logs with file name and line number
 // renderer process - logs without filename or line number
 module.exports = {
-  // Use these in Electron code
-  info: (...args) => logWithOrigin('info', ...args),
-  warn: (...args) => logWithOrigin('warn', ...args),
-  error: (...args) => logWithOrigin('error', ...args),
-  debug: (...args) => logWithOrigin('debug', ...args),
+    // Use these in Electron code
+    info: (...args) => logWithOrigin('info', ...args),
+    warn: (...args) => logWithOrigin('warn', ...args),
+    error: (...args) => logWithOrigin('error', ...args),
+    debug: (...args) => logWithOrigin('debug', ...args),
 
-  // Use these in main to log renderer events
-  raw: {
-    info: (...args) => log.info('[Renderer]', ...args),
-    warn: (...args) => log.warn('[Renderer]', ...args),
-    error: (...args) => log.error('[Renderer]', ...args),
-    debug: (...args) => log.debug('[Renderer]', ...args),
-  }
+    // Use these in main to log renderer events
+    raw: {
+        info: (...args) => log.info('[Renderer]', ...args),
+        warn: (...args) => log.warn('[Renderer]', ...args),
+        error: (...args) => log.error('[Renderer]', ...args),
+        debug: (...args) => log.debug('[Renderer]', ...args),
+    }
 };


### PR DESCRIPTION
Added service layer and ipc layer. Follows separations of concern like MVC patten.

### main.cjs 
- Entry point of the application

### preload.cjs 
- Responsible for exposing ipc handlers to the renderer

### ipc/  
- Similar to router + controller layer of mvc
- Responsible for defining handlers (analogy: router), formatting req/ res, handling error 
- Should be lean

### services/ 
- Similar to service layer of mvc
- Handles core business logic

### db/ (pending)
- Similar to model + repository layer of mvc
- Should contain models, orm integration, seeders, general repository functions

### utils/
- Utility functions like logging etc.
